### PR TITLE
Add expense with name and amount

### DIFF
--- a/lib/common/utils/app_theme.dart
+++ b/lib/common/utils/app_theme.dart
@@ -174,27 +174,9 @@ class AppTheme {
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
       fillColor: Colors.white,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(
-          color: AppColors.gunmetal.withValues(alpha: 0.2),
-          width: 1,
-        ),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(
-          color: AppColors.gunmetal.withValues(alpha: 0.2),
-          width: 1,
-        ),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: const BorderSide(
-          color: AppColors.gunmetal,
-          width: 2,
-        ),
-      ),
+      border: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      focusedBorder: InputBorder.none,
       errorBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide(

--- a/lib/common/utils/app_theme.dart
+++ b/lib/common/utils/app_theme.dart
@@ -201,6 +201,14 @@ class AppTheme {
       thickness: 1,
       space: 1,
     ),
+    snackBarTheme: SnackBarThemeData(
+      backgroundColor: AppColors.gunmetal,
+      contentTextStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+      ),
+    ),
     iconTheme: const IconThemeData(
       color: AppColors.gunmetal,
       size: 24,

--- a/lib/common/utils/date_utils.dart
+++ b/lib/common/utils/date_utils.dart
@@ -15,8 +15,8 @@ class DateUtils {
     );
   }
 
-  static int toFirebaseTimestamp(DateTime dateTime) {
-    return dateTime.millisecondsSinceEpoch;
+  static FieldValue toFirebaseTimestamp(DateTime dateTime) {
+    return FieldValue.serverTimestamp();
   }
 
   static String formatDate(DateTime date) {

--- a/lib/features/budget/application/budget_service.dart
+++ b/lib/features/budget/application/budget_service.dart
@@ -15,6 +15,9 @@ class BudgetService {
   
   Future<List<ExpenseModel>> fetchExpenses() async =>
       await _budgetRepository.fetchExpenses();
+
+  Future<void> addExpense(ExpenseModel expense) async =>
+      await _budgetRepository.addExpense(expense);
 }
 
 final budgetServiceProvider = Provider<BudgetService>((ref) {

--- a/lib/features/budget/data/budget_repository.dart
+++ b/lib/features/budget/data/budget_repository.dart
@@ -6,6 +6,7 @@ abstract class BudgetRepository {
   Future<bool> isBudgetCreated();
   Future<void> createBudget();
   Future<List<ExpenseModel>> fetchExpenses();
+  Future<void> addExpense(ExpenseModel expense);
 }
 
 final budgetRepositoryProvider = Provider.family<BudgetRepository, String>((

--- a/lib/features/budget/data/firebase_budget_repository.dart
+++ b/lib/features/budget/data/firebase_budget_repository.dart
@@ -64,6 +64,29 @@ class FirebaseBudgetRepository implements BudgetRepository {
       rethrow;
     }
   }
+
+  @override
+  Future<void> addExpense(ExpenseModel expense) async {
+    try {
+      final budgetQuerySnapshot = await _firestore
+          .collection('budgets')
+          .where('userId', isEqualTo: _userId)
+          .get();
+
+      if (budgetQuerySnapshot.docs.isEmpty) {
+        throw Exception('Budget not found for user');
+      }
+
+      final budgetDoc = budgetQuerySnapshot.docs.first;
+
+      await budgetDoc.reference
+          .collection('expenses')
+          .add(expense.toFirebaseMap());
+    } catch (e) {
+      print('Error adding expense to Firebase: $e');
+      rethrow;
+    }
+  }
 }
 
 final firebaseBudgetRepositoryProvider =

--- a/lib/features/budget/domain/expense_model.dart
+++ b/lib/features/budget/domain/expense_model.dart
@@ -1,4 +1,5 @@
 import 'package:budget/common/utils/date_utils.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class ExpenseModel {
   final String id;
@@ -27,12 +28,11 @@ class ExpenseModel {
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toFirebaseMap() {
     return {
-      'id': id,
       'name': name,
       'amount': amount,
-      'createdAt': DateUtils.toFirebaseTimestamp(createdAt),
+      'createdAt': FieldValue.serverTimestamp(),
     };
   }
 

--- a/lib/features/budget/presentation/add_expense_controller.dart
+++ b/lib/features/budget/presentation/add_expense_controller.dart
@@ -1,0 +1,27 @@
+import 'package:budget/features/budget/application/budget_service.dart';
+import 'package:budget/features/budget/domain/expense_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AddExpenseController extends StateNotifier<AsyncValue<void>> {
+  final BudgetService _budgetService;
+
+  AddExpenseController(this._budgetService)
+    : super(const AsyncValue.data(null));
+
+  Future<void> addExpense(String name, double amount) async {
+    state = const AsyncValue.loading();
+    final expense = ExpenseModel(
+      id: '',
+      name: name,
+      amount: amount,
+      createdAt: DateTime.now(),
+    );
+    state = await AsyncValue.guard(() => _budgetService.addExpense(expense));
+  }
+}
+
+final addExpenseControllerProvider =
+    StateNotifierProvider<AddExpenseController, AsyncValue<void>>((ref) {
+      final budgetService = ref.watch(budgetServiceProvider);
+      return AddExpenseController(budgetService);
+    });

--- a/lib/features/budget/presentation/add_expense_item.dart
+++ b/lib/features/budget/presentation/add_expense_item.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart' hide DateUtils;
+
+import 'package:budget/common/utils/colors.dart';
+import 'package:budget/common/utils/date_utils.dart';
+
+class AddExpenseItem extends StatelessWidget {
+  const AddExpenseItem({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: 12.0,
+          right: 6.0,
+          top: 2.0,
+          bottom: 2.0,
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 40,
+              child: Text(
+                DateUtils.formatDate(DateTime.now()),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: AppColors.gunmetal.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
+            Expanded(
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: 'Type description',
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.gunmetal.withValues(alpha: 0.5),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
+            SizedBox(
+              width: 100,
+              child: TextField(
+                keyboardType: TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(
+                  hintText: '0.00',
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.gunmetal.withValues(alpha: 0.5),
+                  ),
+                ),
+                textAlign: TextAlign.right,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/budget/presentation/add_expense_item.dart
+++ b/lib/features/budget/presentation/add_expense_item.dart
@@ -21,13 +21,24 @@ class _AddExpenseItemState extends ConsumerState<AddExpenseItem> {
   final FocusNode _amountFocusNode = FocusNode();
 
   @override
+  void initState() {
+    super.initState();
+    _nameController.addListener(_onTextChanged);
+    _amountController.addListener(_onTextChanged);
+  }
+
+  @override
   void dispose() {
+    _nameController.removeListener(_onTextChanged);
+    _amountController.removeListener(_onTextChanged);
     _nameController.dispose();
     _amountController.dispose();
     _nameFocusNode.dispose();
     _amountFocusNode.dispose();
     super.dispose();
   }
+
+  void _onTextChanged() => setState(() {});
 
   void _handleSubmit() {
     final name = _nameController.text.trim();
@@ -143,11 +154,40 @@ class _AddExpenseItemState extends ConsumerState<AddExpenseItem> {
                 onSubmitted: (_) => _handleSubmit(),
               ),
             ),
-            if (addExpenseState.isLoading)
-              const SizedBox(
-                width: 20,
-                height: 20,
-                child: CircularProgressIndicator(strokeWidth: 2),
+            const SizedBox(width: 8),
+            if (_nameController.text.trim().isNotEmpty &&
+                _amountController.text.trim().isNotEmpty)
+              Container(
+                decoration: BoxDecoration(
+                  color: addExpenseState.isLoading
+                      ? AppColors.gunmetal.withValues(alpha: 0.1)
+                      : AppColors.gunmetal,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: addExpenseState.isLoading ? null : _handleSubmit,
+                    borderRadius: BorderRadius.circular(8),
+                    child: Container(
+                      width: 32,
+                      height: 32,
+                      alignment: Alignment.center,
+                      child: addExpenseState.isLoading
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  Colors.white,
+                                ),
+                              ),
+                            )
+                          : Icon(Icons.check, color: Colors.white, size: 18),
+                    ),
+                  ),
+                ),
               ),
           ],
         ),

--- a/lib/features/budget/presentation/add_expense_item.dart
+++ b/lib/features/budget/presentation/add_expense_item.dart
@@ -1,13 +1,89 @@
 import 'package:flutter/material.dart' hide DateUtils;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:budget/common/utils/colors.dart';
 import 'package:budget/common/utils/date_utils.dart';
+import 'package:budget/features/budget/presentation/add_expense_controller.dart';
 
-class AddExpenseItem extends StatelessWidget {
-  const AddExpenseItem({super.key});
+class AddExpenseItem extends ConsumerStatefulWidget {
+  final VoidCallback onExpenseAdded;
+
+  const AddExpenseItem({super.key, required this.onExpenseAdded});
+
+  @override
+  ConsumerState<AddExpenseItem> createState() => _AddExpenseItemState();
+}
+
+class _AddExpenseItemState extends ConsumerState<AddExpenseItem> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _amountController = TextEditingController();
+  final FocusNode _nameFocusNode = FocusNode();
+  final FocusNode _amountFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    _nameFocusNode.dispose();
+    _amountFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit() {
+    final name = _nameController.text.trim();
+    final amountText = _amountController.text.trim();
+
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a description')),
+      );
+      _nameFocusNode.requestFocus();
+      return;
+    }
+
+    if (amountText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter an amount')),
+      );
+      _amountFocusNode.requestFocus();
+      return;
+    }
+
+    final amount = double.tryParse(amountText);
+    if (amount == null || amount <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please enter a valid amount greater than 0'),
+        ),
+      );
+      _amountFocusNode.requestFocus();
+      return;
+    }
+
+    final controller = ref.read(addExpenseControllerProvider.notifier);
+    controller.addExpense(name, amount).then((_) {
+      final state = ref.read(addExpenseControllerProvider);
+      state.when(
+        data: (_) {
+          _nameController.clear();
+          _amountController.clear();
+          widget.onExpenseAdded();
+        },
+        loading: () {},
+        error: (error, stackTrace) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Failed to add expense: ${error.toString()}'),
+            ),
+          );
+        },
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    final addExpenseState = ref.watch(addExpenseControllerProvider);
     return Card(
       margin: const EdgeInsets.only(bottom: 16),
       child: Padding(
@@ -30,6 +106,9 @@ class AddExpenseItem extends StatelessWidget {
             ),
             Expanded(
               child: TextField(
+                controller: _nameController,
+                focusNode: _nameFocusNode,
+                textCapitalization: TextCapitalization.words,
                 decoration: InputDecoration(
                   hintText: 'Type description',
                   border: InputBorder.none,
@@ -40,12 +119,15 @@ class AddExpenseItem extends StatelessWidget {
                     color: AppColors.gunmetal.withValues(alpha: 0.5),
                   ),
                 ),
+                onSubmitted: (_) => _amountFocusNode.requestFocus(),
               ),
             ),
             const SizedBox(width: 16),
             SizedBox(
               width: 100,
               child: TextField(
+                controller: _amountController,
+                focusNode: _amountFocusNode,
                 keyboardType: TextInputType.numberWithOptions(decimal: true),
                 decoration: InputDecoration(
                   hintText: '0.00',
@@ -58,8 +140,15 @@ class AddExpenseItem extends StatelessWidget {
                   ),
                 ),
                 textAlign: TextAlign.right,
+                onSubmitted: (_) => _handleSubmit(),
               ),
             ),
+            if (addExpenseState.isLoading)
+              const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
           ],
         ),
       ),

--- a/lib/features/budget/presentation/budget_screen.dart
+++ b/lib/features/budget/presentation/budget_screen.dart
@@ -40,7 +40,7 @@ class _BudgetScreenState extends ConsumerState<BudgetScreen> {
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [_total(context), _expenses(context)],
           ),
         ),
@@ -60,7 +60,9 @@ class _BudgetScreenState extends ConsumerState<BudgetScreen> {
     return budgetAsync.when(
       data: (budgetModel) => Text(
         MoneyUtils.formatMoney(budgetModel.totalExpense),
-        style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+        style: Theme.of(
+          context,
+        ).textTheme.displayLarge?.copyWith(
           fontWeight: FontWeight.bold,
         ),
       ),
@@ -87,7 +89,13 @@ class _BudgetScreenState extends ConsumerState<BudgetScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SectionTitle(title: 'EXPENSES'),
-          if (_showAddExpenseItem) const AddExpenseItem(),
+          if (_showAddExpenseItem)
+            AddExpenseItem(
+              onExpenseAdded: () {
+                setState(() => _showAddExpenseItem = false);
+                ref.read(budgetControllerProvider.notifier).fetchExpenses();
+              },
+            ),
           ...budgetModel.expenses.map(
             (expense) => ExpenseItem(expense: expense),
           ),

--- a/lib/features/budget/presentation/budget_screen.dart
+++ b/lib/features/budget/presentation/budget_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:budget/features/budget/presentation/budget_controller.dart';
 import 'package:budget/common/utils/money_utils.dart';
 import 'package:budget/features/budget/presentation/expense_item.dart';
+import 'package:budget/common/utils/colors.dart';
+import 'package:budget/features/budget/presentation/add_expense_item.dart';
 
 class BudgetScreen extends ConsumerStatefulWidget {
   const BudgetScreen({super.key});
@@ -14,6 +16,8 @@ class BudgetScreen extends ConsumerStatefulWidget {
 }
 
 class _BudgetScreenState extends ConsumerState<BudgetScreen> {
+  bool _showAddExpenseItem = false;
+
   @override
   void initState() {
     super.initState();
@@ -41,6 +45,13 @@ class _BudgetScreenState extends ConsumerState<BudgetScreen> {
           ),
         ),
       ),
+      floatingActionButton: _showAddExpenseItem
+          ? null
+          : FloatingActionButton(
+              onPressed: () => setState(() => _showAddExpenseItem = true),
+              backgroundColor: AppColors.gunmetal,
+              child: const Icon(Icons.add, color: Colors.white),
+            ),
     );
   }
 
@@ -76,6 +87,7 @@ class _BudgetScreenState extends ConsumerState<BudgetScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SectionTitle(title: 'EXPENSES'),
+          if (_showAddExpenseItem) const AddExpenseItem(),
           ...budgetModel.expenses.map(
             (expense) => ExpenseItem(expense: expense),
           ),

--- a/test/common/utils/date_utils_test.dart
+++ b/test/common/utils/date_utils_test.dart
@@ -139,52 +139,33 @@ void main() {
     });
 
     group('toFirebaseTimestamp', () {
-      test('should convert DateTime to milliseconds timestamp', () {
+      test('should return FieldValue.serverTimestamp()', () {
         // Arrange
         final testDateTime = DateTime(2024, 1, 15, 10, 30, 45);
-        final expectedMilliseconds = testDateTime.millisecondsSinceEpoch;
 
         // Act
         final result = DateUtils.toFirebaseTimestamp(testDateTime);
 
         // Assert
-        expect(result, equals(expectedMilliseconds));
+        expect(result, isA<FieldValue>());
+        expect(result, equals(FieldValue.serverTimestamp()));
       });
 
-      test('should handle DateTime with zero milliseconds', () {
+      test('should return FieldValue.serverTimestamp() for any DateTime', () {
         // Arrange
-        final testDateTime = DateTime.fromMillisecondsSinceEpoch(0);
-        const expectedMilliseconds = 0;
+        final testDateTime1 = DateTime.fromMillisecondsSinceEpoch(0);
+        final testDateTime2 = DateTime.now();
+        final testDateTime3 = DateTime(2024, 1, 15, 10, 30, 45, 123, 456);
 
         // Act
-        final result = DateUtils.toFirebaseTimestamp(testDateTime);
+        final result1 = DateUtils.toFirebaseTimestamp(testDateTime1);
+        final result2 = DateUtils.toFirebaseTimestamp(testDateTime2);
+        final result3 = DateUtils.toFirebaseTimestamp(testDateTime3);
 
         // Assert
-        expect(result, equals(expectedMilliseconds));
-      });
-
-      test('should handle current DateTime', () {
-        // Arrange
-        final testDateTime = DateTime.now();
-        final expectedMilliseconds = testDateTime.millisecondsSinceEpoch;
-
-        // Act
-        final result = DateUtils.toFirebaseTimestamp(testDateTime);
-
-        // Assert
-        expect(result, equals(expectedMilliseconds));
-      });
-
-      test('should handle DateTime with microseconds', () {
-        // Arrange
-        final testDateTime = DateTime(2024, 1, 15, 10, 30, 45, 123, 456);
-        final expectedMilliseconds = testDateTime.millisecondsSinceEpoch;
-
-        // Act
-        final result = DateUtils.toFirebaseTimestamp(testDateTime);
-
-        // Assert
-        expect(result, equals(expectedMilliseconds));
+        expect(result1, equals(FieldValue.serverTimestamp()));
+        expect(result2, equals(FieldValue.serverTimestamp()));
+        expect(result3, equals(FieldValue.serverTimestamp()));
       });
     });
 

--- a/test/features/budget/presentation/add_expense_controller_test.dart
+++ b/test/features/budget/presentation/add_expense_controller_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:budget/features/budget/presentation/add_expense_controller.dart';
+import 'package:budget/features/budget/application/budget_service.dart';
+import 'package:budget/features/budget/domain/expense_model.dart';
+
+class MockBudgetService implements BudgetService {
+  Exception? _addExpenseError;
+  bool _isBudgetCreated = true;
+  final List<ExpenseModel> _expenses = [];
+
+  void setAddExpenseError(Exception? error) {
+    _addExpenseError = error;
+  }
+
+  void setBudgetCreated(bool isCreated) {
+    _isBudgetCreated = isCreated;
+  }
+
+  @override
+  Future<bool> isBudgetCreated() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    return _isBudgetCreated;
+  }
+
+  @override
+  Future<void> createBudget() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+  }
+
+  @override
+  Future<List<ExpenseModel>> fetchExpenses() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    return _expenses;
+  }
+
+  @override
+  Future<void> addExpense(ExpenseModel expense) async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    if (_addExpenseError != null) {
+      throw _addExpenseError!;
+    }
+    _expenses.add(expense);
+  }
+}
+
+final mockBudgetServiceProvider = Provider<BudgetService>((ref) {
+  return MockBudgetService();
+});
+
+void main() {
+  group('AddExpenseController', () {
+    late ProviderContainer container;
+    late MockBudgetService mockBudgetService;
+    late AddExpenseController controller;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: [
+          budgetServiceProvider.overrideWith((ref) => MockBudgetService()),
+        ],
+      );
+      mockBudgetService =
+          container.read(budgetServiceProvider) as MockBudgetService;
+      controller = container.read(addExpenseControllerProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('should initialize with data state', () {
+      // Act
+      final state = container.read(addExpenseControllerProvider);
+
+      // Assert
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasValue, isTrue);
+    });
+
+    test('should add expense successfully', () async {
+      // Arrange
+      const expenseName = 'Groceries';
+      const expenseAmount = 50.0;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasValue, isTrue);
+      expect(state.hasError, isFalse);
+    });
+
+    test('should set loading state when adding expense', () async {
+      // Arrange
+      const expenseName = 'Gas';
+      const expenseAmount = 30.0;
+
+      // Act
+      final future = controller.addExpense(expenseName, expenseAmount);
+
+      // Assert - Check loading state
+      final loadingState = container.read(addExpenseControllerProvider);
+      expect(loadingState, isA<AsyncLoading<void>>());
+
+      // Wait for completion
+      await future;
+
+      // Assert - Check final state
+      final finalState = container.read(addExpenseControllerProvider);
+      expect(finalState, isA<AsyncData<void>>());
+    });
+
+    test('should handle error when adding expense fails', () async {
+      // Arrange
+      const expenseName = 'Invalid Expense';
+      const expenseAmount = 100.0;
+      final mockError = Exception('Failed to add expense');
+      mockBudgetService.setAddExpenseError(mockError);
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncError<void>>());
+      expect(state.error, equals(mockError));
+      expect(state.hasError, isTrue);
+    });
+
+    test('should create expense with correct properties', () async {
+      // Arrange
+      const expenseName = 'Restaurant';
+      const expenseAmount = 75.5;
+      final beforeTime = DateTime.now();
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added to the service
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+
+      final addedExpense = expenses.first;
+      expect(addedExpense.name, equals(expenseName));
+      expect(addedExpense.amount, equals(expenseAmount));
+      expect(
+        addedExpense.id,
+        equals(''),
+      ); // ID should be empty as per controller
+      expect(addedExpense.createdAt.isAfter(beforeTime), isTrue);
+      expect(addedExpense.createdAt.isBefore(DateTime.now()), isTrue);
+    });
+
+    test('should handle multiple expense additions', () async {
+      // Arrange
+      const expense1Name = 'Groceries';
+      const expense1Amount = 50.0;
+      const expense2Name = 'Gas';
+      const expense2Amount = 30.0;
+
+      // Act
+      await controller.addExpense(expense1Name, expense1Amount);
+      await controller.addExpense(expense2Name, expense2Amount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify both expenses were added
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(2));
+      expect(expenses[0].name, equals(expense1Name));
+      expect(expenses[0].amount, equals(expense1Amount));
+      expect(expenses[1].name, equals(expense2Name));
+      expect(expenses[1].amount, equals(expense2Amount));
+    });
+
+    test('should handle zero amount expense', () async {
+      // Arrange
+      const expenseName = 'Free Item';
+      const expenseAmount = 0.0;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+      expect(expenses.first.amount, equals(0.0));
+    });
+
+    test('should handle negative amount expense', () async {
+      // Arrange
+      const expenseName = 'Refund';
+      const expenseAmount = -25.0;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added with negative amount
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+      expect(expenses.first.amount, equals(-25.0));
+    });
+
+    test('should handle empty expense name', () async {
+      // Arrange
+      const expenseName = '';
+      const expenseAmount = 10.0;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added with empty name
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+      expect(expenses.first.name, equals(''));
+    });
+
+    test('should handle very large amount', () async {
+      // Arrange
+      const expenseName = 'Large Purchase';
+      const expenseAmount = 999999.99;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added with large amount
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+      expect(expenses.first.amount, equals(999999.99));
+    });
+
+    test('should handle decimal precision correctly', () async {
+      // Arrange
+      const expenseName = 'Precise Amount';
+      const expenseAmount = 123.456;
+
+      // Act
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify the expense was added with precise amount
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(1));
+      expect(expenses.first.amount, equals(123.456));
+    });
+
+    test('should maintain state consistency after error recovery', () async {
+      // Arrange
+      const expenseName = 'Test Expense';
+      const expenseAmount = 25.0;
+      final mockError = Exception('Temporary error');
+      mockBudgetService.setAddExpenseError(mockError);
+
+      // Act - First attempt (should fail)
+      await controller.addExpense(expenseName, expenseAmount);
+      final errorState = container.read(addExpenseControllerProvider);
+      expect(errorState, isA<AsyncError<void>>());
+
+      // Clear error and try again
+      mockBudgetService.setAddExpenseError(null);
+      await controller.addExpense(expenseName, expenseAmount);
+
+      // Assert - Should recover successfully
+      final successState = container.read(addExpenseControllerProvider);
+      expect(successState, isA<AsyncData<void>>());
+      expect(successState.hasError, isFalse);
+    });
+
+    test('should handle concurrent expense additions', () async {
+      // Arrange
+      const expense1Name = 'Expense 1';
+      const expense1Amount = 10.0;
+      const expense2Name = 'Expense 2';
+      const expense2Amount = 20.0;
+
+      // Act - Start both additions concurrently
+      final future1 = controller.addExpense(expense1Name, expense1Amount);
+      final future2 = controller.addExpense(expense2Name, expense2Amount);
+
+      // Wait for both to complete
+      await Future.wait([future1, future2]);
+
+      // Assert
+      final state = container.read(addExpenseControllerProvider);
+      expect(state, isA<AsyncData<void>>());
+      expect(state.hasError, isFalse);
+
+      // Verify both expenses were added
+      final expenses = await mockBudgetService.fetchExpenses();
+      expect(expenses.length, equals(2));
+    });
+  });
+}

--- a/test/features/budget/presentation/add_expense_item_test.dart
+++ b/test/features/budget/presentation/add_expense_item_test.dart
@@ -1,0 +1,440 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:budget/features/budget/presentation/add_expense_item.dart';
+import 'package:budget/features/budget/application/budget_service.dart';
+import 'package:budget/features/budget/domain/expense_model.dart';
+
+class MockBudgetService implements BudgetService {
+  Exception? _addExpenseError;
+  bool _isBudgetCreated = true;
+  final List<ExpenseModel> _expenses = [];
+
+  void setAddExpenseError(Exception? error) {
+    _addExpenseError = error;
+  }
+
+  void setBudgetCreated(bool isCreated) {
+    _isBudgetCreated = isCreated;
+  }
+
+  @override
+  Future<bool> isBudgetCreated() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    return _isBudgetCreated;
+  }
+
+  @override
+  Future<void> createBudget() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+  }
+
+  @override
+  Future<List<ExpenseModel>> fetchExpenses() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    return _expenses;
+  }
+
+  @override
+  Future<void> addExpense(ExpenseModel expense) async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    if (_addExpenseError != null) {
+      throw _addExpenseError!;
+    }
+    _expenses.add(expense);
+  }
+}
+
+final mockBudgetServiceProvider = Provider<BudgetService>((ref) {
+  return MockBudgetService();
+});
+
+void main() {
+  group('AddExpenseItem TextField Validations', () {
+    late ProviderContainer container;
+    late MockBudgetService mockBudgetService;
+    bool onExpenseAddedCalled = false;
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: [
+          budgetServiceProvider.overrideWith((ref) => MockBudgetService()),
+        ],
+      );
+      mockBudgetService =
+          container.read(budgetServiceProvider) as MockBudgetService;
+      onExpenseAddedCalled = false;
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    Widget createWidget() {
+      return ProviderScope(
+        // ignore: deprecated_member_use
+        parent: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: AddExpenseItem(
+              onExpenseAdded: () {
+                onExpenseAddedCalled = true;
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    group('Empty Field Validations', () {
+      testWidgets('should show error when description is empty', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter only amount, leave description empty
+        await tester.enterText(amountField, '50.00');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Please enter a description'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should show error when amount is empty', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter only description, leave amount empty, then submit amount field
+        await tester.enterText(descriptionField, 'Groceries');
+        await tester.enterText(amountField, ''); // Ensure amount field is empty
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.text('Please enter an amount'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should show error when both fields are empty', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Submit with empty fields
+        await tester.enterText(descriptionField, '');
+        await tester.enterText(amountField, '');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert - Should show description error first
+        expect(find.text('Please enter a description'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+    });
+
+    group('Amount Validation', () {
+      testWidgets('should show error for invalid amount (non-numeric)', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter invalid amount
+        await tester.enterText(descriptionField, 'Groceries');
+        await tester.enterText(amountField, 'abc');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(
+          find.text('Please enter a valid amount greater than 0'),
+          findsOneWidget,
+        );
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should show error for zero amount', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter zero amount
+        await tester.enterText(descriptionField, 'Free Item');
+        await tester.enterText(amountField, '0');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(
+          find.text('Please enter a valid amount greater than 0'),
+          findsOneWidget,
+        );
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should show error for negative amount', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter negative amount
+        await tester.enterText(descriptionField, 'Refund');
+        await tester.enterText(amountField, '-50.00');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(
+          find.text('Please enter a valid amount greater than 0'),
+          findsOneWidget,
+        );
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should accept valid decimal amounts', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter valid decimal amount
+        await tester.enterText(descriptionField, 'Coffee');
+        await tester.enterText(amountField, '3.50');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should not show error and callback should be called
+        expect(
+          find.text('Please enter a valid amount greater than 0'),
+          findsNothing,
+        );
+        expect(find.byType(SnackBar), findsNothing);
+        expect(onExpenseAddedCalled, isTrue);
+      });
+
+      testWidgets('should accept valid integer amounts', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter valid integer amount
+        await tester.enterText(descriptionField, 'Gas');
+        await tester.enterText(amountField, '45');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should not show error and callback should be called
+        expect(
+          find.text('Please enter a valid amount greater than 0'),
+          findsNothing,
+        );
+        expect(find.byType(SnackBar), findsNothing);
+        expect(onExpenseAddedCalled, isTrue);
+      });
+    });
+
+    group('TextField Behavior', () {
+      testWidgets('should focus amount field when description is submitted', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+
+        // Act - Enter description and submit
+        await tester.enterText(descriptionField, 'Groceries');
+        await tester.testTextInput.receiveAction(TextInputAction.next);
+
+        // Assert - Amount field should be focused (we can verify by checking if it's the active field)
+        // The focus will automatically move to the amount field due to onSubmitted callback
+        expect(find.byType(TextField), findsNWidgets(2));
+      });
+
+      testWidgets('should submit when amount field is submitted', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter valid data and submit amount field
+        await tester.enterText(descriptionField, 'Lunch');
+        await tester.enterText(amountField, '12.99');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should submit successfully
+        expect(onExpenseAddedCalled, isTrue);
+      });
+
+      testWidgets('should clear fields after successful submission', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter data and submit
+        await tester.enterText(descriptionField, 'Dinner');
+        await tester.enterText(amountField, '25.50');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Fields should be cleared
+        expect(find.text('Dinner'), findsNothing);
+        expect(find.text('25.50'), findsNothing);
+        expect(onExpenseAddedCalled, isTrue);
+      });
+    });
+
+    group('Error Handling', () {
+      testWidgets('should show error snackbar when service fails', (
+        tester,
+      ) async {
+        // Arrange
+        mockBudgetService.setAddExpenseError(Exception('Service error'));
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter valid data and submit
+        await tester.enterText(descriptionField, 'Test Expense');
+        await tester.enterText(amountField, '10.00');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should show error message
+        expect(
+          find.text('Failed to add expense: Exception: Service error'),
+          findsOneWidget,
+        );
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(onExpenseAddedCalled, isFalse);
+      });
+
+      testWidgets('should show loading indicator during submission', (
+        tester,
+      ) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter valid data and submit
+        await tester.enterText(descriptionField, 'Loading Test');
+        await tester.enterText(amountField, '15.00');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Assert - Should show loading indicator during the async operation
+        await tester.pump(); // Pump once to trigger the loading state
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Wait for completion
+        await tester.pumpAndSettle();
+
+        // Assert - Loading indicator should be gone
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    group('Input Formatting', () {
+      testWidgets('should handle whitespace in description', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter description with leading/trailing whitespace
+        await tester.enterText(descriptionField, '  Groceries  ');
+        await tester.enterText(amountField, '30.00');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should submit successfully (whitespace is trimmed)
+        expect(onExpenseAddedCalled, isTrue);
+      });
+
+      testWidgets('should handle whitespace in amount', (tester) async {
+        // Arrange
+        await tester.pumpWidget(createWidget());
+
+        // Find text fields
+        final descriptionField = find.byType(TextField).first;
+        final amountField = find.byType(TextField).last;
+
+        // Act - Enter amount with leading/trailing whitespace
+        await tester.enterText(descriptionField, 'Test');
+        await tester.enterText(amountField, '  20.50  ');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+
+        // Wait for async operation
+        await tester.pumpAndSettle();
+
+        // Assert - Should submit successfully (whitespace is trimmed)
+        expect(onExpenseAddedCalled, isTrue);
+      });
+    });
+  });
+}

--- a/test/features/budget/presentation/budget_controller_test.dart
+++ b/test/features/budget/presentation/budget_controller_test.dart
@@ -10,6 +10,7 @@ class MockBudgetService implements BudgetService {
   bool _isBudgetCreated = false;
   Exception? _mockError;
   Exception? _createBudgetError;
+  Exception? _addExpenseError;
 
   void setMockExpenses(List<ExpenseModel> expenses) {
     _mockExpenses = expenses;
@@ -27,6 +28,10 @@ class MockBudgetService implements BudgetService {
 
   void setCreateBudgetError(Exception error) {
     _createBudgetError = error;
+  }
+
+  void setAddExpenseError(Exception error) {
+    _addExpenseError = error;
   }
 
   @override
@@ -50,6 +55,14 @@ class MockBudgetService implements BudgetService {
       throw _mockError!;
     }
     return _mockExpenses ?? [];
+  }
+
+  @override
+  Future<void> addExpense(ExpenseModel expense) async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    if (_addExpenseError != null) {
+      throw _addExpenseError!;
+    }
   }
 }
 


### PR DESCRIPTION
- Closes #5 

# Description

Implement a feature that allows users to add a new expense entry with the following requirements:

- [x] Allow the user to input both a name and an amount for each expense.
- [x] Associate the expense with the current budget.
- [x] Refresh the list of expenses and total amount after the expense is recorded.
- [x] Validate name and amount fields.

This will enable users to log new expenses in the app, improving their ability to track spending.

# Screenshots

![Simulator Screenshot - iPhone 16 Pro - 2025-06-27 at 16 21 09](https://github.com/user-attachments/assets/97f8e71c-91f2-49bf-bd50-5bcf6268a035)
